### PR TITLE
fix: Remove default chrono dep on time for sqlx-cli

### DIFF
--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -34,7 +34,7 @@ sqlx = { version = "0.6.1", path = "..", default-features = false, features = [
 ] }
 futures = "0.3.19"
 clap = { version = "3.1.0", features = ["derive", "env"] }
-chrono = "0.4.19"
+chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 anyhow = "1.0.52"
 url = { version = "2.2.2", default-features = false }
 async-trait = "0.1.52"


### PR DESCRIPTION
**TL;DR:** Remove unnecessary dependency on `time` 0.1 in `sqlx-cli`; that version of `time` is deprecated and contains a vulnerability flagged by `cargo audit`.

**Effects of Change:** This change adjusts the feature flags configured for the `chrono` crate for `sqlx-cli`. It disables default features for `chrono` and enables the `clock` flag only. The outcome is that `chrono` will no longer include the default `oldtime` feature flag which removes the dependency on `time`.

**Why?** `time` 0.1 is deprecated and vulnerable to [RUSTSEC-2020-0071](https://rustsec.org/advisories/RUSTSEC-2020-0071). This also causes `sqlx-cli` to be flagged by `cargo audit`:

```
Crate:     time
Version:   0.1.44
Title:     Potential segfault in the time crate
Date:      2020-11-18
ID:        RUSTSEC-2020-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0071
Solution:  Upgrade to >=0.2.23
Dependency tree:
time 0.1.44
└── chrono 0.4.19
    ├── sqlx-core 0.6.1
    │   ├── sqlx-macros 0.6.1
    │   │   └── sqlx 0.6.1
    │   │       ├── sqlx-test 0.1.0
    │   │       │   └── sqlx 0.6.1
    │   │       ├── sqlx-example-sqlite-todos 0.1.0
    │   │       ├── sqlx-example-postgres-transaction 0.1.0
    │   │       ├── sqlx-example-postgres-todos 0.1.0
    │   │       ├── sqlx-example-postgres-mockable-todos 0.1.0
    │   │       ├── sqlx-example-postgres-listen 0.1.0
    │   │       ├── sqlx-example-postgres-axum-social 0.1.0
    │   │       ├── sqlx-example-mysql-todos 0.1.0
    │   │       ├── sqlx-core 0.6.1
    │   │       ├── sqlx-cli 0.6.1
    │   │       ├── sqlx-bench 0.1.0
    │   │       ├── json 0.1.0
    │   │       └── files 0.1.0
    │   └── sqlx 0.6.1
    ├── sqlx-cli 0.6.1
    ├── sqlx-bench 0.1.0
    └── serde_with 2.0.0
        └── sqlx-example-postgres-axum-social 0.1.0
```

**Potential Followup:** This is probably not the greatest solution given that chrono 0.4.19 [has its own issues](https://rustsec.org/advisories/RUSTSEC-2020-0159), but IMO it's an easy first step before either upgrading `chrono` or replacing with an up to date version of `time`.